### PR TITLE
Make MotionSentinel configurable and add MKV support

### DIFF
--- a/server/MotionSentinel/WatchForge.MotionSentinel.Server.Core.Tests/Services/MotionAnalysisOrchestratorTests.cs
+++ b/server/MotionSentinel/WatchForge.MotionSentinel.Server.Core.Tests/Services/MotionAnalysisOrchestratorTests.cs
@@ -175,7 +175,6 @@ public sealed class MotionAnalysisOrchestratorTests
         var videoSrc = new Mock<IVideoSource>();
         videoSrc.Setup(v => v.GetFramesAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()))
             .Returns(AsyncEnumerable.Empty<VideoFrame>());
-        videoSrc.Setup(v => v.DurationMs).Returns(120_000L);
         videoSrc.Setup(v => v.Width).Returns(1920);
         videoSrc.Setup(v => v.Height).Returns(1080);
         videoSrc.Setup(v => v.FrameRate).Returns(25.0f);
@@ -190,7 +189,6 @@ public sealed class MotionAnalysisOrchestratorTests
         // Then
         var result = JsonSerializer.Deserialize<DetectionResult>(capturedJson!,
             new JsonSerializerOptions { PropertyNameCaseInsensitive = true })!;
-        await Assert.That(result.Metadata.DurationMs).IsEqualTo(120_000L);
         await Assert.That(result.Metadata.Width).IsEqualTo(1920);
         await Assert.That(result.Metadata.Height).IsEqualTo(1080);
         await Assert.That(result.Metadata.FrameRate).IsEqualTo(25.0f);

--- a/server/MotionSentinel/WatchForge.MotionSentinel.Server.Core/Models/VideoMetadata.cs
+++ b/server/MotionSentinel/WatchForge.MotionSentinel.Server.Core/Models/VideoMetadata.cs
@@ -3,9 +3,6 @@ namespace WatchForge.MotionSentinel.Server.Core.Models;
 /// <summary>Technical metadata extracted from the source video file.</summary>
 public sealed record VideoMetadata
 {
-    /// <summary>Total duration of the video in milliseconds.</summary>
-    public long DurationMs { get; init; }
-
     /// <summary>Frame width in pixels.</summary>
     public int Width { get; init; }
 

--- a/server/MotionSentinel/WatchForge.MotionSentinel.Server.Core/Services/IVideoSource.cs
+++ b/server/MotionSentinel/WatchForge.MotionSentinel.Server.Core/Services/IVideoSource.cs
@@ -7,9 +7,6 @@ namespace WatchForge.MotionSentinel.Server.Core.Services;
 /// </summary>
 public interface IVideoSource : IDisposable
 {
-    /// <summary>Total duration of the video in milliseconds.</summary>
-    long DurationMs { get; }
-
     /// <summary>Frame width in pixels.</summary>
     int Width { get; }
 

--- a/server/MotionSentinel/WatchForge.MotionSentinel.Server.Core/Services/MotionAnalysisOrchestrator.cs
+++ b/server/MotionSentinel/WatchForge.MotionSentinel.Server.Core/Services/MotionAnalysisOrchestrator.cs
@@ -120,7 +120,6 @@ public sealed class MotionAnalysisOrchestrator
             AppVersion = _appInfo.Version,
             Metadata   = new VideoMetadata
             {
-                DurationMs          = source.DurationMs,
                 Width               = source.Width,
                 Height              = source.Height,
                 FrameRate           = source.FrameRate,

--- a/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service.Tests/FileAccess/LocalFileServiceTests.cs
+++ b/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service.Tests/FileAccess/LocalFileServiceTests.cs
@@ -16,8 +16,9 @@ public sealed class LocalFileServiceTests
 
         var service = new LocalFileService(Options.Create(new LocalFileServiceOptions
         {
-            RecordingsPath = recDir,
-            DetectionsPath = detDir,
+            WatchDirectory  = recDir,
+            OutputDirectory = detDir,
+            FileExtensions  = ["*.mp4"],
         }));
 
         // When
@@ -40,8 +41,8 @@ public sealed class LocalFileServiceTests
 
         var service = new LocalFileService(Options.Create(new LocalFileServiceOptions
         {
-            RecordingsPath = recDir,
-            DetectionsPath = detDir,
+            WatchDirectory = recDir,
+            OutputDirectory = detDir,
         }));
 
         // When
@@ -59,8 +60,8 @@ public sealed class LocalFileServiceTests
         // Given
         var service = new LocalFileService(Options.Create(new LocalFileServiceOptions
         {
-            RecordingsPath = "/mnt/nvr/recordings",
-            DetectionsPath = "/mnt/nvr/detections",
+            WatchDirectory = "/mnt/nvr/recordings",
+            OutputDirectory = "/mnt/nvr/detections",
         }));
 
         // When
@@ -81,8 +82,8 @@ public sealed class LocalFileServiceTests
 
         var service = new LocalFileService(Options.Create(new LocalFileServiceOptions
         {
-            RecordingsPath = recDir,
-            DetectionsPath = detDir,
+            WatchDirectory = recDir,
+            OutputDirectory = detDir,
         }));
 
         await Assert.That(service.DetectionExists("cam1_08-00.mp4")).IsTrue();
@@ -99,8 +100,8 @@ public sealed class LocalFileServiceTests
 
         var service = new LocalFileService(Options.Create(new LocalFileServiceOptions
         {
-            RecordingsPath = recDir,
-            DetectionsPath = detDir,
+            WatchDirectory = recDir,
+            OutputDirectory = detDir,
         }));
 
         await Assert.That(service.DetectionExists("cam1_08-15.mp4")).IsFalse();
@@ -115,8 +116,8 @@ public sealed class LocalFileServiceTests
     {
         var service = new LocalFileService(Options.Create(new LocalFileServiceOptions
         {
-            RecordingsPath = "/mnt/nvr/recordings",
-            DetectionsPath = "/mnt/nvr/detections",
+            WatchDirectory = "/mnt/nvr/recordings",
+            OutputDirectory = "/mnt/nvr/detections",
         }));
 
         await Assert.ThrowsAsync<ArgumentException>(
@@ -132,8 +133,8 @@ public sealed class LocalFileServiceTests
     {
         var service = new LocalFileService(Options.Create(new LocalFileServiceOptions
         {
-            RecordingsPath = "/mnt/nvr/recordings",
-            DetectionsPath = "/mnt/nvr/detections",
+            WatchDirectory = "/mnt/nvr/recordings",
+            OutputDirectory = "/mnt/nvr/detections",
         }));
 
         await Assert.ThrowsAsync<ArgumentException>(

--- a/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service.Tests/MotionSentinelServiceTests.cs
+++ b/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service.Tests/MotionSentinelServiceTests.cs
@@ -30,7 +30,7 @@ public sealed class MotionSentinelServiceTests
     }
 
     [Test]
-    public async Task StartingAsync_ThrowsDirectoryNotFoundException_WhenRecordingsPathMissing()
+    public async Task StartingAsync_ThrowsDirectoryNotFoundException_WhenWatchDirectoryMissing()
     {
         // Given
         var (orchestrator, _) = BuildOrchestrator();
@@ -38,8 +38,8 @@ public sealed class MotionSentinelServiceTests
             orchestrator,
             Options.Create(new LocalFileServiceOptions
             {
-                RecordingsPath = "/nonexistent/path",
-                DetectionsPath = "/tmp/det",
+                WatchDirectory = "/nonexistent/path",
+                OutputDirectory = "/tmp/det",
             }));
 
         // When / Then
@@ -61,8 +61,8 @@ public sealed class MotionSentinelServiceTests
             orchestrator,
             Options.Create(new LocalFileServiceOptions
             {
-                RecordingsPath = recDir,
-                DetectionsPath = detDir,
+                WatchDirectory = recDir,
+                OutputDirectory = detDir,
             }));
 
         // When

--- a/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service/FileAccess/LocalFileService.cs
+++ b/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service/FileAccess/LocalFileService.cs
@@ -15,14 +15,15 @@ public sealed class LocalFileService : IFileAccessService
     /// <inheritdoc/>
     public Task<IReadOnlyList<string>> ListNewRecordingsAsync(CancellationToken ct = default)
     {
-        var recordings = Directory
-            .EnumerateFiles(_options.RecordingsPath, "*.mp4")
+        var recordings = _options.FileExtensions
+            .SelectMany(ext => Directory.EnumerateFiles(_options.WatchDirectory, ext))
             .Select(Path.GetFileName)
             .OfType<string>()
+            .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         var analyzed = Directory
-            .EnumerateFiles(_options.DetectionsPath, "*.json")
+            .EnumerateFiles(_options.OutputDirectory, "*.json")
             .Select(f => Path.GetFileNameWithoutExtension(f))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
@@ -46,24 +47,24 @@ public sealed class LocalFileService : IFileAccessService
         if (fileName.Contains("..") || fileName.Contains('/') || fileName.Contains('\\'))
             throw new ArgumentException("Path traversal is not allowed.", nameof(fileName));
 
-        return Path.Combine(_options.RecordingsPath, fileName);
+        return Path.Combine(_options.WatchDirectory, fileName);
     }
 
     /// <inheritdoc/>
     public bool DetectionExists(string fileName)
     {
         var jsonName = Path.GetFileNameWithoutExtension(fileName) + ".json";
-        return File.Exists(Path.Combine(_options.DetectionsPath, jsonName));
+        return File.Exists(Path.Combine(_options.OutputDirectory, jsonName));
     }
 
     /// <inheritdoc/>
     public async Task WriteDetectionAsync(
         string jsonContent, string videoFileName, CancellationToken ct = default)
     {
-        Directory.CreateDirectory(_options.DetectionsPath);
+        Directory.CreateDirectory(_options.OutputDirectory);
 
         var jsonName   = Path.GetFileNameWithoutExtension(videoFileName) + ".json";
-        var outputPath = Path.Combine(_options.DetectionsPath, jsonName);
+        var outputPath = Path.Combine(_options.OutputDirectory, jsonName);
 
         await File.WriteAllTextAsync(outputPath, jsonContent, ct);
     }

--- a/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service/FileAccess/LocalFileServiceOptions.cs
+++ b/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service/FileAccess/LocalFileServiceOptions.cs
@@ -1,11 +1,14 @@
 namespace WatchForge.MotionSentinel.Server.Service.FileAccess;
 
-/// <summary>Configuration options for <see cref="LocalFileService"/>, bound from the <c>Files</c> config section.</summary>
+/// <summary>Configuration options for <see cref="LocalFileService"/>, bound from the <c>MotionSentinel</c> config section.</summary>
 public sealed record LocalFileServiceOptions
 {
-    /// <summary>Absolute path to the folder containing NVR MP4 recordings.</summary>
-    public string RecordingsPath { get; init; } = string.Empty;
+    /// <summary>Absolute path to the folder containing NVR recordings.</summary>
+    public string WatchDirectory { get; init; } = string.Empty;
 
     /// <summary>Absolute path where detection JSON files will be written.</summary>
-    public string DetectionsPath { get; init; } = string.Empty;
+    public string OutputDirectory { get; init; } = string.Empty;
+
+    /// <summary>Glob patterns for video files to watch and process (e.g. "*.mp4", "*.mkv").</summary>
+    public IReadOnlyList<string> FileExtensions { get; init; } = ["*.mp4"];
 }

--- a/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service/MotionSentinelService.cs
+++ b/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service/MotionSentinelService.cs
@@ -24,7 +24,7 @@ public sealed class MotionSentinelService : IHostedLifecycleService
     // Tracks filenames currently queued or running to prevent duplicate analysis
     private readonly ConcurrentDictionary<string, byte> _inFlight = new(StringComparer.OrdinalIgnoreCase);
 
-    private FileSystemWatcher? _watcher;
+    private readonly List<FileSystemWatcher> _watchers = [];
     private CancellationTokenSource _cts = new();
 
     public MotionSentinelService(
@@ -39,12 +39,13 @@ public sealed class MotionSentinelService : IHostedLifecycleService
     public Task StartingAsync(CancellationToken ct)
     {
         Log.Info("MotionSentinel starting.");
-        Log.Info($"Recordings : {_fileOptions.RecordingsPath}");
-        Log.Info($"Detections : {_fileOptions.DetectionsPath}");
+        Log.Info($"Watch      : {_fileOptions.WatchDirectory}");
+        Log.Info($"Output     : {_fileOptions.OutputDirectory}");
+        Log.Info($"Extensions : {string.Join(", ", _fileOptions.FileExtensions)}");
 
-        if (!Directory.Exists(_fileOptions.RecordingsPath))
+        if (!Directory.Exists(_fileOptions.WatchDirectory))
             throw new DirectoryNotFoundException(
-                $"RecordingsPath not found: {_fileOptions.RecordingsPath}");
+                $"WatchDirectory not found: {_fileOptions.WatchDirectory}");
 
         return Task.CompletedTask;
     }
@@ -56,20 +57,24 @@ public sealed class MotionSentinelService : IHostedLifecycleService
         await _orchestrator.RunBackfillAsync(_cts.Token);
     }
 
-    /// <summary>Called after <see cref="StartAsync"/> — activates the <see cref="FileSystemWatcher"/> to process new recordings in real time.</summary>
+    /// <summary>Called after <see cref="StartAsync"/> — activates one <see cref="FileSystemWatcher"/> per configured extension to process new recordings in real time.</summary>
     public Task StartedAsync(CancellationToken ct)
     {
-        _watcher = new FileSystemWatcher(_fileOptions.RecordingsPath, "*.mp4")
+        foreach (var ext in _fileOptions.FileExtensions)
         {
-            NotifyFilter          = NotifyFilters.FileName | NotifyFilters.Size,
-            IncludeSubdirectories = false,
-            EnableRaisingEvents   = true,
-        };
+            var watcher = new FileSystemWatcher(_fileOptions.WatchDirectory, ext)
+            {
+                NotifyFilter          = NotifyFilters.FileName | NotifyFilters.Size,
+                IncludeSubdirectories = false,
+                EnableRaisingEvents   = true,
+            };
 
-        _watcher.Created += OnFileCreated;
-        _watcher.Renamed += OnFileRenamed;
+            watcher.Created += OnFileCreated;
+            watcher.Renamed += OnFileRenamed;
+            _watchers.Add(watcher);
+        }
 
-        Log.Info("FileSystemWatcher active — waiting for new recordings...");
+        Log.Info($"FileSystemWatcher active ({_watchers.Count} filter(s)) — waiting for new recordings...");
         return Task.CompletedTask;
     }
 
@@ -78,8 +83,8 @@ public sealed class MotionSentinelService : IHostedLifecycleService
     {
         Log.Info("MotionSentinel stopping — draining in-flight analysis...");
 
-        if (_watcher is not null)
-            _watcher.EnableRaisingEvents = false;
+        foreach (var watcher in _watchers)
+            watcher.EnableRaisingEvents = false;
 
         await _cts.CancelAsync();
 
@@ -95,7 +100,9 @@ public sealed class MotionSentinelService : IHostedLifecycleService
     public Task StoppedAsync(CancellationToken ct)
     {
         Log.Info("MotionSentinel stopped.");
-        _watcher?.Dispose();
+        foreach (var watcher in _watchers)
+            watcher.Dispose();
+        _watchers.Clear();
         return Task.CompletedTask;
     }
 

--- a/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service/Program.cs
+++ b/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service/Program.cs
@@ -14,7 +14,7 @@ Log4NetConfigurator.Configure(logDir);
 
 // Configuration bindings
 builder.Services.Configure<LocalFileServiceOptions>(
-    builder.Configuration.GetSection("Files"));
+    builder.Configuration.GetSection("MotionSentinel"));
 
 builder.Services.Configure<DetectionOptions>(
     builder.Configuration.GetSection("Detection"));

--- a/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service/VideoSources/FileVideoSource.cs
+++ b/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service/VideoSources/FileVideoSource.cs
@@ -11,9 +11,6 @@ public sealed class FileVideoSource : IVideoSource
     private readonly VideoCapture _capture;
 
     /// <inheritdoc/>
-    public long  DurationMs { get; }
-
-    /// <inheritdoc/>
     public int   Width      { get; }
 
     /// <inheritdoc/>
@@ -38,8 +35,6 @@ public sealed class FileVideoSource : IVideoSource
         Width     = (int)_capture.Get(VideoCaptureProperties.FrameWidth);
         Height    = (int)_capture.Get(VideoCaptureProperties.FrameHeight);
 
-        long frameCount = (long)_capture.Get(VideoCaptureProperties.FrameCount);
-        DurationMs = fps > 0 ? (long)(frameCount * 1000.0 / fps) : 0;
     }
 
     /// <inheritdoc/>

--- a/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service/appsettings.json
+++ b/server/MotionSentinel/WatchForge.MotionSentinel.Server.Service/appsettings.json
@@ -1,9 +1,10 @@
 {
   "LogDirectory": "/var/log/motionsentinel",
 
-  "Files": {
-    "RecordingsPath": "/mnt/nvr/recordings",
-    "DetectionsPath": "/mnt/nvr/detections"
+  "MotionSentinel": {
+    "WatchDirectory": "/mnt/nvr/recordings/",
+    "OutputDirectory": "/mnt/nvr/detections/",
+    "FileExtensions": [ "*.mp4", "*.mkv" ]
   },
 
   "Detection": {


### PR DESCRIPTION
- Move watch/output directories and file extensions to appsettings.json under the MotionSentinel config section
- Support multiple file extensions (mp4, mkv) via one FileSystemWatcher per extension instead of a single hardcoded *.mp4 watcher
- Backfill on startup now respects all configured extensions
- Remove DurationMs from VideoMetadata and IVideoSource — unreliable for MKV containers and unused by any downstream consumer
- Update tests accordingly